### PR TITLE
Change default output stream for webpack errors

### DIFF
--- a/src/tasks/build.ts
+++ b/src/tasks/build.ts
@@ -142,7 +142,7 @@ export class BuildTasks {
             if (args['webpack-stats']) {
               console.log(stats.toString({ colors: true }));
             } else {
-              console.log(stats.toString('errors-only'));
+              console.error(stats.toString('errors-only'));
             }
             resolve();
           });


### PR DESCRIPTION
closes #34 

used this command for the tests: `npm run build 1>log_out.txt 2>log_error.txt`

make pr in master because dev branch not actual 


